### PR TITLE
Refactor how we generate Direction in the logs. So much nicer.

### DIFF
--- a/commands/clean.go
+++ b/commands/clean.go
@@ -19,30 +19,30 @@ func cleanRun(cmd *cobra.Command, args []string) {
 	if ConfigFile != "" {
 		LoadConfig(ConfigFile)
 	}
-	checkCleanFlags(Direction)
+	checkCleanFlags()
 
-	CompareFile := CompareFilename(FiletoClean, Direction)
-	LastFile := LastFilename(FiletoClean, Direction)
+	CompareFile := CompareFilename(FiletoClean)
+	LastFile := LastFilename(FiletoClean)
 
-	RemoveFile(FiletoClean, Direction)
-	RemoveFile(CompareFile, Direction)
-	RemoveFile(LastFile, Direction)
+	RemoveFile(FiletoClean)
+	RemoveFile(CompareFile)
+	RemoveFile(LastFile)
 
 	// Run this command after the files are cleaned.
 	if PostExec != "" {
-		Log(fmt.Sprintf("%s: exec='%s'", Direction, PostExec), "debug")
+		Log(fmt.Sprintf("exec='%s'", PostExec), "debug")
 		RunCommand(PostExec)
 	}
-	RunTime(start, "none", "complete", Direction, DogStatsd)
+	RunTime(start, "none", "complete", DogStatsd)
 }
 
-func checkCleanFlags(direction string) {
-	Log(fmt.Sprintf("%s: Checking cli flags.", direction), "debug")
+func checkCleanFlags() {
+	Log("Checking cli flags.", "debug")
 	if FiletoClean == "" {
 		fmt.Println("Need a file to clean in -f")
 		os.Exit(1)
 	}
-	Log(fmt.Sprintf("%s: Required cli flags present.", direction), "debug")
+	Log("Required cli flags present.", "debug")
 }
 
 var (

--- a/commands/consul.go
+++ b/commands/consul.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func Connect(server, token, direction string) (*consul.Client, error) {
+func Connect(server, token string) (*consul.Client, error) {
 	var cleanedToken = ""
 	config := consul.DefaultConfig()
 	config.Address = server
@@ -15,18 +15,18 @@ func Connect(server, token, direction string) (*consul.Client, error) {
 		cleanedToken = cleanupToken(token)
 	}
 	consul, _ := consul.NewClient(config)
-	Log(fmt.Sprintf("%s: server='%s' token='%s'", direction, server, cleanedToken), "debug")
+	Log(fmt.Sprintf("server='%s' token='%s'", server, cleanedToken), "debug")
 	return consul, nil
 }
 
-func Get(c *consul.Client, key string, direction string, dogstatsd bool) string {
+func Get(c *consul.Client, key string, dogstatsd bool) string {
 	var value string
 	kv := c.KV()
 	pair, _, err := kv.Get(key, nil)
 	if err != nil {
-		Log(fmt.Sprintf("%s: action='get' panic='true' key='%s'", direction, key), "info")
+		Log(fmt.Sprintf("action='get' panic='true' key='%s'", key), "info")
 		if dogstatsd {
-			StatsdPanic(key, direction, "consul_get")
+			StatsdPanic(key, "consul_get")
 		}
 	} else {
 		if pair != nil {
@@ -34,20 +34,20 @@ func Get(c *consul.Client, key string, direction string, dogstatsd bool) string 
 		} else {
 			value = ""
 		}
-		Log(fmt.Sprintf("%s: action='get' key='%s'", direction, key), "debug")
+		Log(fmt.Sprintf("action='get' key='%s'", key), "debug")
 	}
 	return value
 }
 
-func GetRaw(c *consul.Client, prefix string, key string, direction string, dogstatsd bool) string {
+func GetRaw(c *consul.Client, prefix string, key string, dogstatsd bool) string {
 	var value string
 	kv := c.KV()
 	full_key := fmt.Sprintf("%s/%s", prefix, key)
 	pair, _, err := kv.Get(full_key, nil)
 	if err != nil {
-		Log(fmt.Sprintf("%s: action='get_raw' panic='true' key='%s'", direction, full_key), "info")
+		Log(fmt.Sprintf("action='get_raw' panic='true' key='%s'", full_key), "info")
 		if dogstatsd {
-			StatsdPanic(full_key, direction, "consul_get_raw")
+			StatsdPanic(full_key, "consul_get_raw")
 		}
 	} else {
 		if pair != nil {
@@ -55,7 +55,7 @@ func GetRaw(c *consul.Client, prefix string, key string, direction string, dogst
 		} else {
 			value = ""
 		}
-		Log(fmt.Sprintf("%s: action='get_raw' key='%s'", direction, full_key), "debug")
+		Log(fmt.Sprintf("action='get_raw' key='%s'", full_key), "debug")
 	}
 	return value
 }
@@ -66,17 +66,17 @@ func cleanupToken(token string) string {
 	return firstString
 }
 
-func Set(c *consul.Client, key string, value string, direction string, dogstatsd bool) bool {
+func Set(c *consul.Client, key string, value string, dogstatsd bool) bool {
 	p := &consul.KVPair{Key: key, Value: []byte(value)}
 	kv := c.KV()
 	_, err := kv.Put(p, nil)
 	if err != nil {
-		Log(fmt.Sprintf("%s: action='set' panic='true' key='%s'", direction, key), "info")
+		Log(fmt.Sprintf("action='set' panic='true' key='%s'", key), "info")
 		if dogstatsd {
-			StatsdPanic(key, direction, "consul_set")
+			StatsdPanic(key, "consul_set")
 		}
 	} else {
-		Log(fmt.Sprintf("%s: action='set' key='%s'", direction, key), "debug")
+		Log(fmt.Sprintf("action='set' key='%s'", key), "debug")
 		return true
 	}
 	return true

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -8,46 +8,46 @@ import (
 )
 
 func StatsdIn(key string, data_length int, data string) {
-	Log(fmt.Sprintf("in: dogstatsd='true' key='%s' stats='in'", key), "debug")
+	Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='in'", key), "debug")
 	statsd, _ := godspeed.NewDefault()
 	defer statsd.Conn.Close()
-	tags := makeTags(key, "in", "complete")
+	tags := makeTags(key, "complete")
 	statsd.Incr("kvexpress.in", tags)
 	statsd.Gauge("kvexpress.bytes", float64(data_length), tags)
 	statsd.Gauge("kvexpress.lines", float64(LineCount(data)), tags)
 }
 
 func StatsdOut(key string) {
-	Log(fmt.Sprintf("out: dogstatsd='true' key='%s' stats='out'", key), "debug")
+	Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='out'", key), "debug")
 	statsd, _ := godspeed.NewDefault()
 	defer statsd.Conn.Close()
-	tags := makeTags(key, "out", "complete")
+	tags := makeTags(key, "complete")
 	statsd.Incr("kvexpress.out", tags)
 }
 
 func StatsdRaw(key string) {
-	Log(fmt.Sprintf("out: dogstatsd='true' key='%s' stats='raw'", key), "debug")
+	Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='raw'", key), "debug")
 	statsd, _ := godspeed.NewDefault()
 	defer statsd.Conn.Close()
-	tags := makeTags(key, "raw", "complete")
+	tags := makeTags(key, "complete")
 	statsd.Incr("kvexpress.raw", tags)
 }
 
-func StatsdRunTime(direction string, key string, location string, msec int64) {
-	Log(fmt.Sprintf("%s: dogstatsd='true' key='%s' location='%s' msec='%d'", direction, key, location, msec), "debug")
+func StatsdRunTime(key string, location string, msec int64) {
+	Log(fmt.Sprintf("dogstatsd='true' key='%s' location='%s' msec='%d'", key, location, msec), "debug")
 	statsd, _ := godspeed.NewDefault()
 	defer statsd.Conn.Close()
-	tags := makeTags(key, direction, location)
+	tags := makeTags(key, location)
 	locationTag := fmt.Sprintf("location:%s", location)
 	tags = append(tags, locationTag)
 	statsd.Gauge("kvexpress.time", float64(msec), tags)
 }
 
-func StatsdPanic(key, direction, location string) {
-	Log(fmt.Sprintf("%s: dogstatsd='true' key='%s' location='%s' stats='panic'", direction, key, location), "debug")
+func StatsdPanic(key, location string) {
+	Log(fmt.Sprintf("dogstatsd='true' key='%s' location='%s' stats='panic'", key, location), "debug")
 	statsd, _ := godspeed.NewDefault()
 	defer statsd.Conn.Close()
-	tags := makeTags(key, direction, location)
+	tags := makeTags(key, location)
 	statsd.Incr("kvexpress.panic", tags)
 	// If we're going to panic, we might as well stop right here.
 	// Means we can't connect to Consul, download a URL or
@@ -60,12 +60,12 @@ func DDAPIConnect(api, app string) *datadog.Client {
 	return client
 }
 
-func makeTags(key, direction, location string) []string {
+func makeTags(key, location string) []string {
 	tags := make([]string, 4)
 	keyTag := fmt.Sprintf("key:%s", key)
 	hostname, _ := os.Hostname()
 	hostTag := fmt.Sprintf("host:%s", hostname)
-	directionTag := fmt.Sprintf("direction:%s", direction)
+	directionTag := fmt.Sprintf("direction:%s", Direction)
 	locationTag := fmt.Sprintf("location:%s", location)
 	tags = append(tags, keyTag)
 	tags = append(tags, hostTag)
@@ -75,9 +75,9 @@ func makeTags(key, direction, location string) []string {
 }
 
 // TODO: These three functions are ripe for refactoring to be more Golang like.
-func DDStopEvent(dd *datadog.Client, key, value, direction string) {
-	Log(fmt.Sprintf("%s: datadog='true' DDStopEvent='true' key='%s'", direction, key), "debug")
-	tags := makeTags(key, direction, "stop_key_present")
+func DDStopEvent(dd *datadog.Client, key, value string) {
+	Log(fmt.Sprintf("datadog='true' DDStopEvent='true' key='%s'", key), "debug")
+	tags := makeTags(key, "stop_key_present")
 	tags = append(tags, "kvexpress:stop")
 	title := fmt.Sprintf("Stop key is present: %s. Stopping.", key)
 	event := datadog.Event{Title: title, Text: value, AlertType: "error", Tags: tags}
@@ -87,9 +87,9 @@ func DDStopEvent(dd *datadog.Client, key, value, direction string) {
 	}
 }
 
-func DDSaveDataEvent(dd *datadog.Client, key, value, direction string) {
-	Log(fmt.Sprintf("%s: datadog='true' DDSaveDataEvent='true' key='%s'", direction, key), "debug")
-	tags := makeTags(key, direction, "complete")
+func DDSaveDataEvent(dd *datadog.Client, key, value string) {
+	Log(fmt.Sprintf("datadog='true' DDSaveDataEvent='true' key='%s'", key), "debug")
+	tags := makeTags(key, "complete")
 	tags = append(tags, "kvexpress:success")
 	title := fmt.Sprintf("Updated: %s", key)
 	event := datadog.Event{Title: title, Text: value, AlertType: "info", Tags: tags}
@@ -99,9 +99,9 @@ func DDSaveDataEvent(dd *datadog.Client, key, value, direction string) {
 	}
 }
 
-func DDCopyDataEvent(dd *datadog.Client, keyFrom, keyTo, direction string) {
-	Log(fmt.Sprintf("%s: datadog='true' DDCopyDataEvent='true' keyFrom='%s' keyTo='%s'", direction, keyFrom, keyTo), "debug")
-	tags := makeTags(keyTo, direction, "complete")
+func DDCopyDataEvent(dd *datadog.Client, keyFrom, keyTo string) {
+	Log(fmt.Sprintf("datadog='true' DDCopyDataEvent='true' keyFrom='%s' keyTo='%s'", keyFrom, keyTo), "debug")
+	tags := makeTags(keyTo, "complete")
 	tags = append(tags, "kvexpress:success")
 	tags = append(tags, fmt.Sprintf("keyFrom:%s", keyFrom))
 	title := fmt.Sprintf("Copy: %s to %s", keyFrom, keyTo)
@@ -112,9 +112,9 @@ func DDCopyDataEvent(dd *datadog.Client, keyFrom, keyTo, direction string) {
 	}
 }
 
-func DDSaveStopEvent(dd *datadog.Client, key, value, direction string) {
-	Log(fmt.Sprintf("%s: datadog='true' DDSaveStopEvent='true' key='%s'", direction, key), "debug")
-	tags := makeTags(key, direction, "stop_key_save")
+func DDSaveStopEvent(dd *datadog.Client, key, value string) {
+	Log(fmt.Sprintf("datadog='true' DDSaveStopEvent='true' key='%s'", key), "debug")
+	tags := makeTags(key, "stop_key_save")
 	tags = append(tags, "kvexpress:stop_set")
 	title := fmt.Sprintf("Set Stop Key: %s", key)
 	event := datadog.Event{Title: title, Text: value, AlertType: "warning", Tags: tags}

--- a/commands/key_paths.go
+++ b/commands/key_paths.go
@@ -4,26 +4,26 @@ import (
 	"fmt"
 )
 
-func KeyDataPath(key string, prefix string, direction string) string {
+func KeyDataPath(key string, prefix string) string {
 	full_path := fmt.Sprint(prefix, "/", key, "/data")
-	Log(fmt.Sprintf("%s: path='data' full_path='%s'", direction, full_path), "debug")
+	Log(fmt.Sprintf("path='data' full_path='%s'", full_path), "debug")
 	return full_path
 }
 
-func KeyChecksumPath(key string, prefix string, direction string) string {
+func KeyChecksumPath(key string, prefix string) string {
 	full_path := fmt.Sprint(prefix, "/", key, "/checksum")
-	Log(fmt.Sprintf("%s: path='checksum' full_path='%s'", direction, full_path), "debug")
+	Log(fmt.Sprintf("path='checksum' full_path='%s'", full_path), "debug")
 	return full_path
 }
 
-func KeyStopPath(key string, prefix string, direction string) string {
+func KeyStopPath(key string, prefix string) string {
 	full_path := fmt.Sprint(prefix, "/", key, "/stop")
-	Log(fmt.Sprintf("%s: path='stop' full_path='%s'", direction, full_path), "debug")
+	Log(fmt.Sprintf("path='stop' full_path='%s'", full_path), "debug")
 	return full_path
 }
 
-func KeyUpdatedPath(key string, prefix string, direction string) string {
+func KeyUpdatedPath(key string, prefix string) string {
 	full_path := fmt.Sprint(prefix, "/", key, "/updated")
-	Log(fmt.Sprintf("%s: path='updated' full_path='%s'", direction, full_path), "debug")
+	Log(fmt.Sprintf("path='updated' full_path='%s'", full_path), "debug")
 	return full_path
 }

--- a/commands/kvexpress.go
+++ b/commands/kvexpress.go
@@ -15,9 +15,9 @@ func init() {
 	// Nothing happens here.
 }
 
-func LengthCheck(data string, min_length int, direction string) bool {
+func LengthCheck(data string, min_length int) bool {
 	length := LineCount(data)
-	Log(fmt.Sprintf("%s: length='%d' min_length='%d'", direction, length, min_length), "debug")
+	Log(fmt.Sprintf("length='%d' min_length='%d'", length, min_length), "debug")
 	if length >= min_length {
 		return true
 	} else {
@@ -28,9 +28,9 @@ func LengthCheck(data string, min_length int, direction string) bool {
 func ReadUrl(url string, dogstatsd bool) string {
 	resp, err := http.Get(url)
 	if err != nil {
-		Log(fmt.Sprintf("in: function='ReadUrl' panic='true' url='%s'", url), "info")
+		Log(fmt.Sprintf("function='ReadUrl' panic='true' url='%s'", url), "info")
 		if dogstatsd {
-			StatsdPanic(url, "in", "read_url")
+			StatsdPanic(url, "read_url")
 		}
 	}
 	defer resp.Body.Close()
@@ -48,17 +48,17 @@ func LineCount(data string) int {
 	return length
 }
 
-func ComputeChecksum(data string, direction string) string {
+func ComputeChecksum(data string) string {
 	data_bytes := []byte(data)
 	computed_checksum := sha256.Sum256(data_bytes)
 	final_checksum := fmt.Sprintf("%x\n", computed_checksum)
-	Log(fmt.Sprintf("%s: computed_checksum='%s'", direction, final_checksum), "debug")
+	Log(fmt.Sprintf("computed_checksum='%s'", final_checksum), "debug")
 	return final_checksum
 }
 
-func ChecksumCompare(data string, checksum string, direction string) bool {
-	computed_checksum := ComputeChecksum(data, direction)
-	Log(fmt.Sprintf("%s: checksum='%s' computed_checksum='%s'", direction, checksum, computed_checksum), "debug")
+func ChecksumCompare(data string, checksum string) bool {
+	computed_checksum := ComputeChecksum(data)
+	Log(fmt.Sprintf("checksum='%s' computed_checksum='%s'", checksum, computed_checksum), "debug")
 	if strings.TrimSpace(computed_checksum) == strings.TrimSpace(checksum) {
 		return true
 	} else {
@@ -91,7 +91,7 @@ func Diff(last string, current string) string {
 	diff := difflib.Diff(last_strings, current_strings)
 	diffString := fmt.Sprintf("%v", diff)
 
-	Log("in: doing the diff", "debug")
+	Log("doing the diff", "debug")
 	buffer.WriteString(diffString)
 	return buffer.String()
 }

--- a/commands/raw.go
+++ b/commands/raw.go
@@ -20,39 +20,39 @@ func rawRun(cmd *cobra.Command, args []string) {
 	if ConfigFile != "" {
 		LoadConfig(ConfigFile)
 	}
-	checkRawFlags(Direction)
+	checkRawFlags()
 
-	c, _ := Connect(ConsulServer, Token, Direction)
+	c, _ := Connect(ConsulServer, Token)
 
 	// Get the KV data out of Consul.
-	KVData := GetRaw(c, PrefixLocation, RawKeyOutLocation, Direction, DogStatsd)
+	KVData := GetRaw(c, PrefixLocation, RawKeyOutLocation, DogStatsd)
 
 	// Is the data long enough?
-	longEnough := LengthCheck(KVData, MinFileLength, Direction)
-	Log(fmt.Sprintf("%s: longEnough='%s'", Direction, strconv.FormatBool(longEnough)), "debug")
+	longEnough := LengthCheck(KVData, MinFileLength)
+	Log(fmt.Sprintf("longEnough='%s'", strconv.FormatBool(longEnough)), "debug")
 
 	// If the data is long enough, write the file.
 	if longEnough {
 		// Acually write the file.
-		WriteFile(KVData, RawFiletoWrite, FilePermissions, Owner, Direction, DogStatsd)
+		WriteFile(KVData, RawFiletoWrite, FilePermissions, Owner, DogStatsd)
 		if DogStatsd {
 			StatsdRaw(RawKeyOutLocation)
 		}
 	} else {
-		Log(fmt.Sprintf("%s: longEnough='no'", Direction), "info")
+		Log("longEnough='no'", "info")
 		os.Exit(0)
 	}
 
 	// Run this command after the file is written.
 	if PostExec != "" {
-		Log(fmt.Sprintf("%s: exec='%s'", Direction, PostExec), "debug")
+		Log(fmt.Sprintf("exec='%s'", PostExec), "debug")
 		RunCommand(PostExec)
 	}
-	RunTime(start, RawKeyOutLocation, "complete", Direction, DogStatsd)
+	RunTime(start, RawKeyOutLocation, "complete", DogStatsd)
 }
 
-func checkRawFlags(direction string) {
-	Log(fmt.Sprintf("%s: Checking cli flags.", direction), "debug")
+func checkRawFlags() {
+	Log("Checking cli flags.", "debug")
 	if RawKeyOutLocation == "" {
 		fmt.Println("Need a key location in -k")
 		os.Exit(1)
@@ -62,15 +62,15 @@ func checkRawFlags(direction string) {
 		os.Exit(1)
 	}
 	if DogStatsd {
-		Log(fmt.Sprintf("%s: Enabling Dogstatsd metrics.", direction), "debug")
+		Log("Enabling Dogstatsd metrics.", "debug")
 	}
 	if DatadogAPIKey != "" && DatadogAPPKey != "" {
-		Log(fmt.Sprintf("%s: Enabling Datadog API.", direction), "debug")
+		Log("Enabling Datadog API.", "debug")
 	}
 	if Owner == "" {
-		Owner = GetCurrentUsername(direction)
+		Owner = GetCurrentUsername()
 	}
-	Log(fmt.Sprintf("%s: Required cli flags present.", direction), "debug")
+	Log("Required cli flags present.", "debug")
 }
 
 var (

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -21,35 +21,35 @@ func stopRun(cmd *cobra.Command, args []string) {
 	if ConfigFile != "" {
 		LoadConfig(ConfigFile)
 	}
-	checkStopFlags(Direction)
+	checkStopFlags()
 
-	KeyStop := KeyStopPath(KeyStopLocation, PrefixLocation, Direction)
+	KeyStop := KeyStopPath(KeyStopLocation, PrefixLocation)
 
-	c, _ := Connect(ConsulServer, Token, Direction)
+	c, _ := Connect(ConsulServer, Token)
 
 	if DatadogAPIKey != "" && DatadogAPPKey != "" {
 		dog = DDAPIConnect(DatadogAPIKey, DatadogAPPKey)
 	}
 
-	saved := Set(c, KeyStop, KeyStopReason, Direction, DogStatsd)
+	saved := Set(c, KeyStop, KeyStopReason, DogStatsd)
 
 	if saved {
-		Log(fmt.Sprintf("%s: KeyStop='%s' saved='true' KeyStopReason='%s'", Direction, KeyStop, KeyStopReason), "info")
+		Log(fmt.Sprintf("KeyStop='%s' saved='true' KeyStopReason='%s'", KeyStop, KeyStopReason), "info")
 		if DatadogAPIKey != "" && DatadogAPPKey != "" {
-			DDSaveStopEvent(dog, KeyStop, KeyStopReason, Direction)
+			DDSaveStopEvent(dog, KeyStop, KeyStopReason)
 		}
 	}
 
 	// Run this command after the key is stopped.
 	if PostExec != "" {
-		Log(fmt.Sprintf("%s: exec='%s'", Direction, PostExec), "debug")
+		Log(fmt.Sprintf("exec='%s'", PostExec), "debug")
 		RunCommand(PostExec)
 	}
-	RunTime(start, KeyStopLocation, "complete", Direction, DogStatsd)
+	RunTime(start, KeyStopLocation, "complete", DogStatsd)
 }
 
-func checkStopFlags(direction string) {
-	Log(fmt.Sprintf("%s: Checking cli flags.", direction), "debug")
+func checkStopFlags() {
+	Log("Checking cli flags.", "debug")
 	if KeyStopLocation == "" {
 		fmt.Println("Need a key to stop in -k")
 		os.Exit(1)
@@ -59,9 +59,9 @@ func checkStopFlags(direction string) {
 		os.Exit(1)
 	}
 	if DatadogAPIKey != "" && DatadogAPPKey != "" {
-		Log(fmt.Sprintf("%s: Enabling Datadog API.", direction), "debug")
+		Log("Enabling Datadog API.", "debug")
 	}
-	Log(fmt.Sprintf("%s: Required cli flags present.", direction), "debug")
+	Log("Required cli flags present.", "debug")
 }
 
 var (


### PR DESCRIPTION
The way I did it before, `Direction` was scoped to each command's `Run` function.

That was terrible and I ended up passing Direction around like a maniac trying to log everything properly.

To fix that and make it better I:
1. Moved Direction to a Globally available var and made it available everywhere in the package.
2. Removed it from each invocation of `Log`.
3. Added it in the Log function itself - where it could be done once.

I was able to remove a ton of code - this seems much better.
