### PR TITLE
Atomic rename instead of truncate and write in place.

### DIFF
--- a/commands/files.go
+++ b/commands/files.go
@@ -65,12 +65,12 @@ func CheckFullPath(file string) {
 // WriteFile writes a string to a filepath. It also chowns the file to the owner and group
 // of the user running the program if it's not set as a different user.
 func WriteFile(data string, filepath string, perms int, owner string) {
-	tmpFile := fmt.Sprintf("%s.%s", filepath, fileSuffix)
+	tmpFilepath := fmt.Sprintf("%s.%s", filepath, fileSuffix)
 	// If a directory doesn't exist then that's a bad thing.
 	// Caused some problems with Consul and file descriptors after a long weekend erroring.
 	CheckFullPath(filepath)
-	// Write the file to a different name.
-	err := ioutil.WriteFile(tmpFile, []byte(data), os.FileMode(perms))
+	// Write the file to the tmpFilepath.
+	err := ioutil.WriteFile(tmpFilepath, []byte(data), os.FileMode(perms))
 	if err != nil {
 		Log(fmt.Sprintf("function='WriteFile' panic='true' file='%s'", filepath), "info")
 		fmt.Printf("Panic: Could not write file: '%s'\n", filepath)
@@ -78,7 +78,7 @@ func WriteFile(data string, filepath string, perms int, owner string) {
 	}
 	// Rename the file so it's not truncated for 1 microsecond
 	// which is actually important at high velocities.
-	err = os.Rename(tmpFile, filepath)
+	err = os.Rename(tmpFilepath, filepath)
 	if err != nil {
 		Log(fmt.Sprintf("function='Rename' panic='true' file='%s'", filepath), "info")
 		fmt.Printf("Panic: Could not rename file: '%s'\n", filepath)


### PR DESCRIPTION
Instead of writing it in place, write to a different name - then rename the file.

This helps to make sure that processes are watching the file never see a 0-length
file in the middle of an update.

This is being done because ioutil.Writefile truncates any existing file in place
which at high velocities means bad things can happen.

This makes sure that the file is replaced atomically. This also means we can remove the chmod code we added here:

https://github.com/DataDog/kvexpress/issues/78

Since we're always creating a new file - the perms will always be correct.

Original issue: https://github.com/DataDog/kvexpress/issues/88

cc @Arkelenia @calebdoxsey 