### PR TITLE
Let's check errors a little better.

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -9,7 +9,26 @@ import (
 	"os"
 )
 
-// RIPE for refactoring.
+// GetStringConfig grabs the string from the config object.
+func GetStringConfig(c *simpleyaml.Yaml, configValue string) string {
+	result, err := c.Get(configValue).String()
+	if err != nil {
+		Log(fmt.Sprintf("Could not get '%s' from config.", configValue), "info")
+	}
+	if result != "" {
+		return result
+	}
+	return ""
+}
+
+// ParseConfig takes the data from a file and parses the config.
+func ParseConfig(data []byte) *simpleyaml.Yaml {
+	config, err := simpleyaml.NewYaml(data)
+	if err != nil {
+		Log("Could not parse the configuration.", "info")
+	}
+	return config
+}
 
 // LoadConfig opens a file and reads the yaml formatted configuration data.
 // It will set configuration globals and/or ENV variables as required.
@@ -19,40 +38,42 @@ func LoadConfig(filename string) {
 	if err != nil {
 		data = []byte("")
 	}
-	config, err := simpleyaml.NewYaml(data)
+	config := ParseConfig(data)
 
-	datadogHost, _ := config.Get("datadog_host").String()
-
+	datadogHost := GetStringConfig(config, "datadog_host")
 	if datadogHost != "" {
 		os.Setenv("DATADOG_HOST", datadogHost)
 	}
 
-	datadogAPIKey, _ := config.Get("datadog_api_key").String()
+	datadogAPIKey := GetStringConfig(config, "datadog_api_key")
 	if datadogAPIKey != "" {
 		DatadogAPIKey = datadogAPIKey
 	}
 
-	datadogAPPKey, _ := config.Get("datadog_app_key").String()
+	datadogAPPKey := GetStringConfig(config, "datadog_app_key")
 	if datadogAPPKey != "" {
 		DatadogAPPKey = datadogAPPKey
 	}
 
-	token, _ := config.Get("token").String()
+	token := GetStringConfig(config, "token")
 	if token != "" {
 		Token = token
 	}
 
-	consulServer, _ := config.Get("consul_server").String()
+	consulServer := GetStringConfig(config, "consul_server")
 	if consulServer != "" {
 		ConsulServer = consulServer
 	}
 
-	dogstatsd, _ := config.Get("dogstatsd").Bool()
+	dogstatsd, err := config.Get("dogstatsd").Bool()
+	if err != nil {
+		Log("Could not get 'dogstatsd' from config.", "info")
+	}
 	if dogstatsd {
 		DogStatsd = true
 	}
 
-	dogstatsdAddress, _ := config.Get("dogstatsd_address").String()
+	dogstatsdAddress := GetStringConfig(config, "dogstatsd_address")
 	if dogstatsdAddress != "" {
 		DogStatsdAddress = dogstatsdAddress
 	}

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -1,0 +1,37 @@
+// +build linux darwin freebsd
+
+package commands
+
+import (
+	"github.com/smallfish/simpleyaml"
+	"testing"
+)
+
+var yaml = `---
+  datadog_api_key: api-key-goes-here
+  datadog_app_key: app-key-goes-here
+  consul_server: 127.0.0.1:8501
+  token: abcd-efgh-hijk-lmno-pqrs-tuvw
+  dogstatsd: true
+  dogstatsd_address: 127.0.0.1:8125
+  datadog_host: https://app.datadoghq.com`
+
+var stringVars = []string{"datadog_api_key", "datadog_app_key", "consul_server", "token", "dogstatsd_address", "datadog_host"}
+
+func loadTestConfigValues(data string) *simpleyaml.Yaml {
+	yamlBytes := []byte(data)
+	config := ParseConfig(yamlBytes)
+	return config
+}
+
+func TestConfigValues(t *testing.T) {
+	config := loadTestConfigValues(yaml)
+	for _, configName := range stringVars {
+		t.Logf("Getting configuration for '%s'", configName)
+		configValue := GetStringConfig(config, configName)
+		if configValue == "" {
+			t.Errorf("Could not get the config for '%s'", configName)
+		}
+		t.Logf("Value: %s", configValue)
+	}
+}

--- a/commands/consul.go
+++ b/commands/consul.go
@@ -100,6 +100,9 @@ func Set(c *consul.Client, key string, value string) bool {
 	Retry(func() error {
 		var err error
 		success, err = consulSet(c, key, value)
+		if success != true {
+			StatsdConsul(key, "set")
+		}
 		return err
 	}, consulTries)
 	return true
@@ -124,6 +127,9 @@ func Del(c *consul.Client, key string) bool {
 	Retry(func() error {
 		var err error
 		success, err = consulDel(c, key)
+		if success != true {
+			StatsdConsul(key, "delete")
+		}
 		return err
 	}, consulTries)
 	return true

--- a/commands/consul.go
+++ b/commands/consul.go
@@ -18,6 +18,7 @@ func Connect(server string, token string) (*consul.Client, error) {
 	consul, err := consulConnect(server, token)
 	if err != nil {
 		Log("Consul connection is bad.", "info")
+		return nil, err
 	}
 	return consul, err
 }

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -29,7 +29,10 @@ func copyRun(cmd *cobra.Command, args []string) {
 	KeyData := KeyPath(KeyFrom, "data")
 	KeyChecksum := KeyPath(KeyFrom, "checksum")
 
-	c, _ := Connect(ConsulServer, Token)
+	c, err := Connect(ConsulServer, Token)
+	if err != nil {
+		LogFatal("Could not connect to Consul.", KeyFrom, "consul_connect")
+	}
 
 	if DatadogAPIKey != "" && DatadogAPPKey != "" {
 		dog = DDAPIConnect(DatadogAPIKey, DatadogAPPKey)

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -9,21 +9,33 @@ import (
 	"os"
 )
 
+// StatsdSetup sets up the connection to dogstatsd.
+func StatsdSetup() *godspeed.Godspeed {
+	statsd, err := godspeed.NewDefault()
+	if err != nil {
+		Log("StatsdSetup(): Problem setting up connection.", "info")
+		return nil
+	}
+	return statsd
+}
+
 // StatsdIn sends metrics to Dogstatsd on a `kvexpress in` operation.
 func StatsdIn(key string, dataLength int, data string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='in'", key), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, "complete")
-		statsd.Incr("kvexpress.in", tags)
-		statsd.Gauge("kvexpress.bytes", float64(dataLength), tags)
-		// If the data is compressed - then LineCount will always return 1.
-		// That's not useful or accurate, so let's decompress and count that.
-		if Compress {
-			data = DecompressData(data)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, "complete")
+			statsd.Incr("kvexpress.in", tags)
+			statsd.Gauge("kvexpress.bytes", float64(dataLength), tags)
+			// If the data is compressed - then LineCount will always return 1.
+			// That's not useful or accurate, so let's decompress and count that.
+			if Compress {
+				data = DecompressData(data)
+			}
+			statsd.Gauge("kvexpress.lines", float64(LineCount(data)), tags)
 		}
-		statsd.Gauge("kvexpress.lines", float64(LineCount(data)), tags)
 	}
 }
 
@@ -31,10 +43,12 @@ func StatsdIn(key string, dataLength int, data string) {
 func StatsdOut(key string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='out'", key), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, "complete")
-		statsd.Incr("kvexpress.out", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, "complete")
+			statsd.Incr("kvexpress.out", tags)
+		}
 	}
 }
 
@@ -43,10 +57,12 @@ func StatsdOut(key string) {
 func StatsdLocked(file string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' file='%s' stats='locked'", file), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(file, "complete")
-		statsd.Incr("kvexpress.locked", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(file, "complete")
+			statsd.Incr("kvexpress.locked", tags)
+		}
 	}
 }
 
@@ -55,10 +71,12 @@ func StatsdLocked(file string) {
 func StatsdLength(key string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='not_long_enough'", key), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, "not_long_enough")
-		statsd.Incr("kvexpress.not_long_enough", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, "not_long_enough")
+			statsd.Incr("kvexpress.not_long_enough", tags)
+		}
 	}
 }
 
@@ -67,10 +85,12 @@ func StatsdLength(key string) {
 func StatsdChecksum(key string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='checksum_mismatch'", key), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, "checksum_mismatch")
-		statsd.Incr("kvexpress.checksum_mismatch", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, "checksum_mismatch")
+			statsd.Incr("kvexpress.checksum_mismatch", tags)
+		}
 	}
 }
 
@@ -78,10 +98,12 @@ func StatsdChecksum(key string) {
 func StatsdLock(key string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='lock'", key), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, "complete")
-		statsd.Incr("kvexpress.lock", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, "complete")
+			statsd.Incr("kvexpress.lock", tags)
+		}
 	}
 }
 
@@ -89,10 +111,12 @@ func StatsdLock(key string) {
 func StatsdUnlock(key string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='unlock'", key), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, "complete")
-		statsd.Incr("kvexpress.unlock", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, "complete")
+			statsd.Incr("kvexpress.unlock", tags)
+		}
 	}
 }
 
@@ -100,10 +124,12 @@ func StatsdUnlock(key string) {
 func StatsdRaw(key string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='raw'", key), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, "complete")
-		statsd.Incr("kvexpress.raw", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, "complete")
+			statsd.Incr("kvexpress.raw", tags)
+		}
 	}
 }
 
@@ -111,15 +137,17 @@ func StatsdRaw(key string) {
 func StatsdReconnect(times int) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' reconnect='%d'", times), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := make([]string, 2)
-		hostname := GetHostname()
-		hostTag := fmt.Sprintf("host:%s", hostname)
-		directionTag := fmt.Sprintf("direction:%s", Direction)
-		tags = append(tags, hostTag)
-		tags = append(tags, directionTag)
-		statsd.Incr("kvexpress.consul_reconnect", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := make([]string, 2)
+			hostname := GetHostname()
+			hostTag := fmt.Sprintf("host:%s", hostname)
+			directionTag := fmt.Sprintf("direction:%s", Direction)
+			tags = append(tags, hostTag)
+			tags = append(tags, directionTag)
+			statsd.Incr("kvexpress.consul_reconnect", tags)
+		}
 	}
 }
 
@@ -127,12 +155,14 @@ func StatsdReconnect(times int) {
 func StatsdRunTime(key string, location string, msec int64) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' location='%s' msec='%d'", key, location, msec), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, location)
-		locationTag := fmt.Sprintf("location:%s", location)
-		tags = append(tags, locationTag)
-		statsd.Gauge("kvexpress.time", float64(msec), tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, location)
+			locationTag := fmt.Sprintf("location:%s", location)
+			tags = append(tags, locationTag)
+			statsd.Gauge("kvexpress.time", float64(msec), tags)
+		}
 	}
 }
 
@@ -141,10 +171,12 @@ func StatsdRunTime(key string, location string, msec int64) {
 func StatsdPanic(key, location string) {
 	if DogStatsd {
 		Log(fmt.Sprintf("dogstatsd='true' key='%s' location='%s' stats='panic'", key, location), "debug")
-		statsd, _ := godspeed.NewDefault()
-		defer statsd.Conn.Close()
-		tags := makeTags(key, location)
-		statsd.Incr("kvexpress.panic", tags)
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, location)
+			statsd.Incr("kvexpress.panic", tags)
+		}
 	}
 	// If we're going to panic, we might as well stop right here.
 	// Means we can't connect to Consul, download a URL or

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -184,6 +184,19 @@ func StatsdPanic(key, location string) {
 	os.Exit(0)
 }
 
+// StatsdConsul sends metrics to DogStatsd when Consul has a KV write or delete error.
+func StatsdConsul(key, location string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' location='%s' stats='consul_error'", DogStatsd, key, location), "info")
+	if DogStatsd {
+		statsd := StatsdSetup()
+		if statsd != nil {
+			defer statsd.Conn.Close()
+			tags := makeTags(key, location)
+			statsd.Incr("kvexpress.consul_error", tags)
+		}
+	}
+}
+
 // DDAPIConnect connects to the Datadog API and returns a client object.
 func DDAPIConnect(api, app string) *datadog.Client {
 	client := datadog.NewClient(api, app)

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -114,7 +114,7 @@ func StatsdReconnect(times int) {
 		statsd, _ := godspeed.NewDefault()
 		defer statsd.Conn.Close()
 		tags := make([]string, 2)
-		hostname, _ := os.Hostname()
+		hostname := GetHostname()
 		hostTag := fmt.Sprintf("host:%s", hostname)
 		directionTag := fmt.Sprintf("direction:%s", Direction)
 		tags = append(tags, hostTag)

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -21,8 +21,8 @@ func StatsdSetup() *godspeed.Godspeed {
 
 // StatsdIn sends metrics to Dogstatsd on a `kvexpress in` operation.
 func StatsdIn(key string, dataLength int, data string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' stats='in'", DogStatsd, key), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='in'", key), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -41,8 +41,8 @@ func StatsdIn(key string, dataLength int, data string) {
 
 // StatsdOut sends metrics to Dogstatsd on a `kvexpress out` operation.
 func StatsdOut(key string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' stats='out'", DogStatsd, key), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='out'", key), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -55,8 +55,8 @@ func StatsdOut(key string) {
 // StatsdLocked sends metrics to Dogstatsd on a `kvexpress out` operation
 // that is blocked by a locked file.
 func StatsdLocked(file string) {
+	Log(fmt.Sprintf("dogstatsd='%t' file='%s' stats='locked'", DogStatsd, file), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' file='%s' stats='locked'", file), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -69,8 +69,8 @@ func StatsdLocked(file string) {
 // StatsdLength sends metrics to Dogstatsd on a `kvexpress out` operation
 // where the file isn't long enough.
 func StatsdLength(key string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' stats='not_long_enough'", DogStatsd, key), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='not_long_enough'", key), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -83,8 +83,8 @@ func StatsdLength(key string) {
 // StatsdChecksum sends metrics to Dogstatsd on a `kvexpress out` operation
 // where the checksum doesn't match.
 func StatsdChecksum(key string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' stats='checksum_mismatch'", DogStatsd, key), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='checksum_mismatch'", key), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -96,8 +96,8 @@ func StatsdChecksum(key string) {
 
 // StatsdLock sends metrics to Dogstatsd on a `kvexpress lock` operation.
 func StatsdLock(key string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' stats='lock'", DogStatsd, key), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='lock'", key), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -109,8 +109,8 @@ func StatsdLock(key string) {
 
 // StatsdUnlock sends metrics to Dogstatsd on a `kvexpress unlock` operation.
 func StatsdUnlock(key string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' stats='unlock'", DogStatsd, key), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='unlock'", key), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -122,8 +122,8 @@ func StatsdUnlock(key string) {
 
 // StatsdRaw sends metrics to Dogstatsd on a `kvexpress raw` operation.
 func StatsdRaw(key string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' stats='raw'", DogStatsd, key), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' stats='raw'", key), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -135,8 +135,8 @@ func StatsdRaw(key string) {
 
 // StatsdReconnect sends metrics when we have Consul connection retries.
 func StatsdReconnect(times int) {
+	Log(fmt.Sprintf("dogstatsd='%t' reconnect='%d'", DogStatsd, times), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' reconnect='%d'", times), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -153,8 +153,8 @@ func StatsdReconnect(times int) {
 
 // StatsdRunTime sends metrics to Dogstatsd on various operations.
 func StatsdRunTime(key string, location string, msec int64) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' location='%s' msec='%d'", DogStatsd, key, location, msec), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' location='%s' msec='%d'", key, location, msec), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()
@@ -169,8 +169,8 @@ func StatsdRunTime(key string, location string, msec int64) {
 // StatsdPanic sends metrics to Dogstatsd when something really bad happens.
 // It also stops the execution of kvexpress.
 func StatsdPanic(key, location string) {
+	Log(fmt.Sprintf("dogstatsd='%t' key='%s' location='%s' stats='panic'", DogStatsd, key, location), "debug")
 	if DogStatsd {
-		Log(fmt.Sprintf("dogstatsd='true' key='%s' location='%s' stats='panic'", key, location), "debug")
 		statsd := StatsdSetup()
 		if statsd != nil {
 			defer statsd.Conn.Close()

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -214,9 +214,9 @@ func DDStopEvent(dd *datadog.Client, key, value string) {
 	tags = append(tags, "kvexpress:stop")
 	title := fmt.Sprintf("Stop key is present: %s. Stopping.", key)
 	event := datadog.Event{Title: title, Text: value, AlertType: "error", Tags: tags}
-	post, _ := dd.PostEvent(&event)
-	if post != nil {
-
+	post, err := dd.PostEvent(&event)
+	if (post == nil) || (err != nil) {
+		Log("DDStopEvent(): Error posting to Datadog.", "info")
 	}
 }
 
@@ -227,9 +227,9 @@ func DDLengthEvent(dd *datadog.Client, key, value string) {
 	tags = append(tags, "kvexpress:length")
 	title := fmt.Sprintf("Not long enough: %s. Stopping.", key)
 	event := datadog.Event{Title: title, Text: value, AlertType: "error", Tags: tags}
-	post, _ := dd.PostEvent(&event)
-	if post != nil {
-
+	post, err := dd.PostEvent(&event)
+	if (post == nil) || (err != nil) {
+		Log("DDLengthEvent(): Error posting to Datadog.", "info")
 	}
 }
 
@@ -240,9 +240,9 @@ func DDSaveDataEvent(dd *datadog.Client, key, value string) {
 	tags = append(tags, "kvexpress:success")
 	title := fmt.Sprintf("Updated: %s", key)
 	event := datadog.Event{Title: title, Text: value, AlertType: "info", Tags: tags}
-	post, _ := dd.PostEvent(&event)
-	if post != nil {
-
+	post, err := dd.PostEvent(&event)
+	if (post == nil) || (err != nil) {
+		Log("DDSaveDataEvent(): Error posting to Datadog.", "info")
 	}
 }
 
@@ -255,9 +255,9 @@ func DDCopyDataEvent(dd *datadog.Client, keyFrom, keyTo string) {
 	tags = append(tags, fmt.Sprintf("keyFrom:%s", keyFrom))
 	title := fmt.Sprintf("Copy: %s to %s", keyFrom, keyTo)
 	event := datadog.Event{Title: title, Text: title, AlertType: "info", Tags: tags}
-	post, _ := dd.PostEvent(&event)
-	if post != nil {
-
+	post, err := dd.PostEvent(&event)
+	if (post == nil) || (err != nil) {
+		Log("DDCopyDataEvent(): Error posting to Datadog.", "info")
 	}
 }
 
@@ -268,8 +268,8 @@ func DDSaveStopEvent(dd *datadog.Client, key, value string) {
 	tags = append(tags, "kvexpress:stop_set")
 	title := fmt.Sprintf("Set Stop Key: %s", key)
 	event := datadog.Event{Title: title, Text: value, AlertType: "warning", Tags: tags}
-	post, _ := dd.PostEvent(&event)
-	if post != nil {
-
+	post, err := dd.PostEvent(&event)
+	if (post == nil) || (err != nil) {
+		Log("DDSaveStopEvent(): Error posting to Datadog.", "info")
 	}
 }

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -194,7 +194,7 @@ func DDAPIConnect(api, app string) *datadog.Client {
 func makeTags(key, location string) []string {
 	tags := make([]string, 4)
 	keyTag := fmt.Sprintf("key:%s", key)
-	hostname, _ := os.Hostname()
+	hostname := GetHostname()
 	hostTag := fmt.Sprintf("host:%s", hostname)
 	directionTag := fmt.Sprintf("direction:%s", Direction)
 	locationTag := fmt.Sprintf("location:%s", location)

--- a/commands/files.go
+++ b/commands/files.go
@@ -120,7 +120,10 @@ func CheckFiletoWrite(filename, checksum string) {
 		Log(fmt.Sprintf("Can NOT write a directory %s", filename), "info")
 		os.Exit(1)
 	default:
-		data, _ := ioutil.ReadFile(filename)
+		data, err := ioutil.ReadFile(filename)
+		if err != nil {
+			Log(fmt.Sprintf("CheckFiletoWrite(): Error reading file: '%s'", filename), "info")
+		}
 		computedChecksum := ComputeChecksum(string(data))
 		if computedChecksum == checksum {
 			Log(fmt.Sprintf("'%s' has the same checksum. Stopping.", filename), "info")

--- a/commands/in.go
+++ b/commands/in.go
@@ -44,7 +44,10 @@ func inRun(cmd *cobra.Command, args []string) {
 	CheckFiletoWrite(CompareFile, "")
 	CheckFiletoWrite(LastFile, "")
 
-	c, _ := Connect(ConsulServer, Token)
+	c, err := Connect(ConsulServer, Token)
+	if err != nil {
+		LogFatal("Could not connect to Consul.", KeyInLocation, "consul_connect")
+	}
 
 	if DatadogAPIKey != "" && DatadogAPPKey != "" {
 		dog = DDAPIConnect(DatadogAPIKey, DatadogAPPKey)

--- a/commands/kvexpress.go
+++ b/commands/kvexpress.go
@@ -114,7 +114,10 @@ func GenerateLockReason() string {
 
 // LockFile sets a key in Consul so that a particular file won't be updated. See commands/lock.go
 func LockFile(key string) bool {
-	c, _ := Connect(ConsulServer, Token)
+	c, err := Connect(ConsulServer, Token)
+	if err != nil {
+		LogFatal("Could not connect to Consul.", key, "consul_connect")
+	}
 	saved := Set(c, key, LockReason)
 	if saved {
 		StatsdLock(key)
@@ -125,7 +128,10 @@ func LockFile(key string) bool {
 
 // UnlockFile removes a key in Consul so that a particular file can be updated. See commands/unlock.go
 func UnlockFile(key string) bool {
-	c, _ := Connect(ConsulServer, Token)
+	c, err := Connect(ConsulServer, Token)
+	if err != nil {
+		LogFatal("copy: Could not connect to Consul.", key, "consul_connect")
+	}
 	value := Del(c, key)
 	StatsdUnlock(key)
 	return value

--- a/commands/kvexpress.go
+++ b/commands/kvexpress.go
@@ -79,10 +79,7 @@ func ChecksumCompare(data string, checksum string) bool {
 
 // UnixDiff runs diff to generate text for the Datadog events.
 func UnixDiff(old, new string) string {
-	diff, err := exec.Command("diff", "-u", old, new).Output()
-	if err != nil {
-		return "There was an error generating the diff."
-	}
+	diff, _ := exec.Command("diff", "-u", old, new).Output()
 	text := string(diff)
 	finalText := removeLines(text, 3)
 	return finalText

--- a/commands/kvexpress.go
+++ b/commands/kvexpress.go
@@ -35,7 +35,11 @@ func ReadURL(url string) string {
 		StatsdPanic(url, "read_url")
 	}
 	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		Log(fmt.Sprintf("ReadURL(): Error reading '%s'", url), "info")
+		return fmt.Sprintf("There was an error reading the body of the url: %s", url)
+	}
 	return string(body)
 }
 

--- a/commands/kvexpress.go
+++ b/commands/kvexpress.go
@@ -75,7 +75,10 @@ func ChecksumCompare(data string, checksum string) bool {
 
 // UnixDiff runs diff to generate text for the Datadog events.
 func UnixDiff(old, new string) string {
-	diff, _ := exec.Command("diff", "-u", old, new).Output()
+	diff, err := exec.Command("diff", "-u", old, new).Output()
+	if err != nil {
+		return "There was an error generating the diff."
+	}
 	text := string(diff)
 	finalText := removeLines(text, 3)
 	return finalText

--- a/commands/out.go
+++ b/commands/out.go
@@ -28,7 +28,10 @@ func outRun(cmd *cobra.Command, args []string) {
 	KeyStop := KeyPath(KeyOutLocation, "stop")
 	KeyLock := FileLockPath(FiletoWrite)
 
-	c, _ := Connect(ConsulServer, Token)
+	c, err := Connect(ConsulServer, Token)
+	if err != nil {
+		LogFatal("Could not connect to Consul.", KeyOutLocation, "consul_connect")
+	}
 
 	LockKeyData := Get(c, KeyLock)
 

--- a/commands/raw.go
+++ b/commands/raw.go
@@ -24,7 +24,10 @@ var rawCmd = &cobra.Command{
 func rawRun(cmd *cobra.Command, args []string) {
 	start := time.Now()
 
-	c, _ := Connect(ConsulServer, Token)
+	c, err := Connect(ConsulServer, Token)
+	if err != nil {
+		LogFatal("Could not connect to Consul.", RawKeyOutLocation, "consul_connect")
+	}
 
 	// Get the KV data out of Consul.
 	KVData := Get(c, RawKeyOutLocation)

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -27,7 +27,10 @@ func stopRun(cmd *cobra.Command, args []string) {
 
 	KeyStop := KeyPath(KeyStopLocation, "stop")
 
-	c, _ := Connect(ConsulServer, Token)
+	c, err := Connect(ConsulServer, Token)
+	if err != nil {
+		LogFatal("Could not connect to Consul.", KeyStopLocation, "consul_connect")
+	}
 
 	if DatadogAPIKey != "" && DatadogAPPKey != "" {
 		dog = DDAPIConnect(DatadogAPIKey, DatadogAPPKey)

--- a/commands/util.go
+++ b/commands/util.go
@@ -76,7 +76,11 @@ func LogFatal(message string, id string, location string) {
 
 // GetCurrentUsername grabs the current user running the kvexpress binary.
 func GetCurrentUsername() string {
-	usr, _ := user.Current()
+	usr, err := user.Current()
+	if err != nil {
+		Log("GetCurrentUsername(): user.Current has failed.", "info")
+		return ""
+	}
 	username := usr.Username
 	Log(fmt.Sprintf("username='%s'", username), "debug")
 	return username
@@ -88,7 +92,10 @@ func GetOwnerID(owner string) int {
 	var status = ""
 	usr, err := user.Lookup(owner)
 	if err != nil {
-		usr, _ = user.Current()
+		usr, err = user.Current()
+		if err != nil {
+			Log("GetOwnerID(): Both user.Lookup and user.Current have failed.", "info")
+		}
 		uid = usr.Uid
 		status = "not_found"
 	} else {
@@ -97,6 +104,9 @@ func GetOwnerID(owner string) int {
 	}
 	Log(fmt.Sprintf("owner='%s' status='%s' uid='%s'", owner, status, uid), "debug")
 	uidInt, err := strconv.ParseInt(uid, 10, 64)
+	if err != nil {
+		Log("GetOwnerID(): Could not convert string into UID.", "info")
+	}
 	return int(uidInt)
 }
 
@@ -106,7 +116,10 @@ func GetGroupID(owner string) int {
 	var status = ""
 	usr, err := user.Lookup(owner)
 	if err != nil {
-		usr, _ = user.Current()
+		usr, err = user.Current()
+		if err != nil {
+			Log("GetGroupID(): Both user.Lookup and user.Current have failed.", "info")
+		}
 		gid = usr.Gid
 		status = "not_found"
 	} else {
@@ -115,6 +128,9 @@ func GetGroupID(owner string) int {
 	}
 	Log(fmt.Sprintf("owner='%s' status='%s' gid='%s'", owner, status, gid), "debug")
 	gidInt, err := strconv.ParseInt(gid, 10, 64)
+	if err != nil {
+		Log("GetGroupID(): Could not convert string into GID.", "info")
+	}
 	return int(gidInt)
 }
 
@@ -147,7 +163,12 @@ func DecompressData(data string) string {
 			fmt.Println("Panic: Could not gunzip string.")
 			StatsdPanic("key", "DecompressData")
 		}
-		uncompressed, _ := ioutil.ReadAll(unzipped)
+		uncompressed, err := ioutil.ReadAll(unzipped)
+		if err != nil {
+			Log("function='DecompressData' panic='true' method='ioutil.ReadAll'", "info")
+			fmt.Println("Panic: Could not ioutil.ReadAll string.")
+			StatsdPanic("key", "DecompressData")
+		}
 		Log(fmt.Sprintf("decompressing='true' size='%d'", len(uncompressed)), "info")
 		return string(uncompressed)
 	}

--- a/commands/util.go
+++ b/commands/util.go
@@ -156,7 +156,10 @@ func DecompressData(data string) string {
 
 // GetHostname returns the hostname.
 func GetHostname() string {
-	hostname, _ := os.Hostname()
+	hostname, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
 	return hostname
 }
 

--- a/commands/util.go
+++ b/commands/util.go
@@ -179,7 +179,7 @@ func DecompressData(data string) string {
 func GetHostname() string {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return ""
+		return "unknown"
 	}
 	return hostname
 }


### PR DESCRIPTION
Pursuant to issue #93 - here's the beginning of a PR to rid the code base of the scourge of ", _".

After this is merged we'll add `errcheck` and a few other automatic tests to the [Wercker CI build](https://app.wercker.com/#applications/5636c18fc58cf5996f026d62)