### PR TITLE
Replacing "github.com/zorkian/go-datadog-api" with "gopkg.in/zorkian/go-datadog-api.v1" because kvexpress currently cannot build with go-datadog-api master

### DIFF
--- a/commands/copy.go
+++ b/commands/copy.go
@@ -5,7 +5,7 @@ package commands
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/zorkian/go-datadog-api"
+	"gopkg.in/zorkian/go-datadog-api.v1"
 	"os"
 	"time"
 )

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -5,7 +5,7 @@ package commands
 import (
 	"fmt"
 	"github.com/PagerDuty/godspeed"
-	"github.com/zorkian/go-datadog-api"
+	"gopkg.in/zorkian/go-datadog-api.v1"
 	"os"
 )
 

--- a/commands/in.go
+++ b/commands/in.go
@@ -5,7 +5,7 @@ package commands
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/zorkian/go-datadog-api"
+	"gopkg.in/zorkian/go-datadog-api.v1"
 	"os"
 	"time"
 )

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -5,7 +5,7 @@ package commands
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/zorkian/go-datadog-api"
+	"gopkg.in/zorkian/go-datadog-api.v1"
 	"os"
 	"time"
 )


### PR DESCRIPTION
Therefore falling back to v1 branch.