### PR TITLE
Rejig dogstatsd config

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -4,9 +4,12 @@ package commands
 
 import (
 	"fmt"
-	"github.com/smallfish/simpleyaml"
 	"io/ioutil"
 	"os"
+	"strconv"
+	"strings"
+
+	"github.com/smallfish/simpleyaml"
 )
 
 // GetStringConfig grabs the string from the config object.
@@ -28,6 +31,16 @@ func ParseConfig(data []byte) *simpleyaml.Yaml {
 		Log("Could not parse the configuration.", "info")
 	}
 	return config
+}
+
+func ParseStatsdAddress(address string) (string, int) {
+	host := strings.Split(address, ":")[0]
+	port, err := strconv.Atoi(strings.Split(address, ":")[1])
+	if err != nil {
+		Log("Could not parse dogstatsd address", "info")
+		os.Exit(1)
+	}
+	return host, port
 }
 
 // LoadConfig opens a file and reads the yaml formatted configuration data.
@@ -76,6 +89,7 @@ func LoadConfig(filename string) {
 	dogstatsdAddress := GetStringConfig(config, "dogstatsd_address")
 	if dogstatsdAddress != "" {
 		DogStatsdAddress = dogstatsdAddress
+		DogStatsdHost, DogStatsdPort = ParseStatsdAddress(dogstatsdAddress)
 	}
 
 }

--- a/commands/config.go
+++ b/commands/config.go
@@ -5,9 +5,9 @@ package commands
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/smallfish/simpleyaml"
 )
@@ -34,10 +34,14 @@ func ParseConfig(data []byte) *simpleyaml.Yaml {
 }
 
 func ParseStatsdAddress(address string) (string, int) {
-	host := strings.Split(address, ":")[0]
-	port, err := strconv.Atoi(strings.Split(address, ":")[1])
+	host, portStr, err := net.SplitHostPort(address)
 	if err != nil {
-		Log("Could not parse dogstatsd address", "info")
+		Log(fmt.Sprintf("Could not parse dogstatsd address: '%s'", err), "info")
+		os.Exit(1)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		Log(fmt.Sprintf("Could not parse dogstatsd address: '%s'", err), "info")
 		os.Exit(1)
 	}
 	return host, port

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -4,13 +4,22 @@ package commands
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/PagerDuty/godspeed"
 	"gopkg.in/zorkian/go-datadog-api.v1"
-	"os"
 )
 
 // StatsdSetup sets up the connection to dogstatsd.
 func StatsdSetup() *godspeed.Godspeed {
+	if DogStatsdAddress != "" {
+		statsd, err := godspeed.New(DogStatsdHost, DogStatsdPort, false)
+		if err != nil {
+			Log(fmt.Sprintf("StatsdSetup(): Problem setting up connection. DogStatsdHost='%s' DogStatsdPort='%i'", DogStatsdHost, DogStatsdPort), "info")
+			return nil
+		}
+		return statsd
+	}
 	statsd, err := godspeed.NewDefault()
 	if err != nil {
 		Log("StatsdSetup(): Problem setting up connection.", "info")

--- a/commands/datadog.go
+++ b/commands/datadog.go
@@ -15,7 +15,7 @@ func StatsdSetup() *godspeed.Godspeed {
 	if DogStatsdAddress != "" {
 		statsd, err := godspeed.New(DogStatsdHost, DogStatsdPort, false)
 		if err != nil {
-			Log(fmt.Sprintf("StatsdSetup(): Problem setting up connection. DogStatsdHost='%s' DogStatsdPort='%i'", DogStatsdHost, DogStatsdPort), "info")
+			Log(fmt.Sprintf("StatsdSetup(): Problem setting up connection. DogStatsdHost='%s' DogStatsdPort='%b'", DogStatsdHost, DogStatsdPort), "info")
 			return nil
 		}
 		return statsd

--- a/commands/root.go
+++ b/commands/root.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -56,6 +57,8 @@ var (
 
 	// DogStatsdAddress if you're not running a local Datadog agent.
 	DogStatsdAddress string
+	DogStatsdHost    string
+	DogStatsdPort    int
 
 	// DatadogAPIKey is for sending events to Datadog through the HTTP api.
 	DatadogAPIKey string


### PR DESCRIPTION
Currently, kvexpress says that dogstatsd config is available through `--dogstatsd_address` but this is not true, since `godspeed.NewDefault()` uses the default statsd host/post.

This PR parses DogStatsdAddress into Host and Port for use w/ `godspeed.New()` to setup statsd host and port.

I chose to leave `DogStatsdAddress` as an entrypoint rather than creating new cli options for host and post so as to be backwards compatible. 